### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Fork of [MeepMeep](https://github.com/NoahBres/MeepMeep) that supports [Road Run
 
 6.  At the bottom of the file add the following gradle snippet:
 
-        ```
+        
         repositories {
             maven { url = 'https://maven.brott.dev/' }
         }
@@ -39,7 +39,7 @@ Fork of [MeepMeep](https://github.com/NoahBres/MeepMeep) that supports [Road Run
         dependencies {
             implementation 'com.acmerobotics.roadrunner:MeepMeep:0.1.3'
         }
-        ```
+        
 
 7.  When android studio prompts you to make a gradle sync, click "Sync Now".
     <img src="/images/readme/installationStep7.png" width="644" height="20"/>


### PR DESCRIPTION
Fixed the Gradle Code Snippet (removing unnecessary backticks) in Step 6 of Android Studio Installation:
New README.md
```
repositories {
    maven { url = 'https://maven.brott.dev/' }
}

dependencies {
    implementation 'com.acmerobotics.roadrunner:MeepMeep:0.1.3'
}
```
Current README.md:
<img width="810" alt="image" src="https://github.com/acmerobotics/MeepMeep/assets/112827565/6a8cfb8d-b4d9-4521-943b-ee683643db39">

