### PR TITLE
Correcting legacy Road Runner support reference.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MeepMeep
 
-Fork of [MeepMeep](https://github.com/NoahBres/MeepMeep) that supports [Road Runner 1.0](https://rr.brott.dev/docs/v1-0/new-features/).
+Fork of [MeepMeep](https://github.com/rh-robotics/MeepMeep) that supports [Road Runner 0.5.x](https://rr.brott.dev/docs/v0-5/installation/).
 
 <img src="/images/readme/screen-recording.gif" width="500" height="500"/>
 


### PR DESCRIPTION
This pull request intends to correct what appears to be an error regarding which variant of MeepMeep supports Road Runner 1.0.x vs 0.5.x.

Presently this project's README shows this ...

> ![image](https://github.com/user-attachments/assets/9988f6a5-6c15-474a-aa71-6511f82ee4b0)

Which comprises three problems ...

- Its [this project](https://github.com/acmerobotics/MeepMeep) that supports [Road Runner 1.0.x](https://rr.brott.dev/docs/v1-0/migration/)
- This should instead be redirecting users to a separate fork for [Road Runner 0.5.x](https://rr.brott.dev/docs/v0-5/installation/)
- The [NoahBres/MeepMeep](https://github.com/NoahBres/MeepMeep) project has been replaced by the [rh-robotics/MeepMeep](https://github.com/rh-robotics/MeepMeep) project

To ensure something wasn't overlooked two additional details were identified as confirmation ...

1. The [Road Runner | Migrating from 0.5.x to 1.0.x](https://rr.brott.dev/docs/v1-0/migration/) documentation confirms that the `TrajectorySequenceBuilder` class has been superseded by `TrajectoryActionBuilder`. As expected, the [rh-robotics/MeepMeep](https://github.com/rh-robotics/MeepMeep) project supports the `TrajectorySequenceBuilder` predecessor and [this project](https://github.com/acmerobotics/MeepMeep) supports the `TrajectoryActionBuilder` successor.

> ![image](https://github.com/user-attachments/assets/7b4d9e14-883d-4264-9ca8-d61e4ea3a112)

2. The [Road Runner | MeepMeep](https://rr.brott.dev/docs/meepmeep/) documentation seems to correctly direct users to [this project](https://github.com/acmerobotics/MeepMeep) for 1.0.x MeepMeep and to the [NoahBres/MeepMeep](https://github.com/NoahBres/MeepMeep) project for 0.5.x MeepMeep.

> ![image](https://github.com/user-attachments/assets/fdb077d2-3ef4-43f5-9edf-f9bda9f03301)

All this was brought to attention by this reddit post [r/FTC | We're Taking Over the Development of MeepMeep for RR v0.5.6!](https://www.reddit.com/r/FTC/comments/1fogyn4/were_taking_over_the_development_of_meepmeep_for/). From which the following comments sparked some temporary confusion which, once sorted out, led to this pull request.

> ![image](https://github.com/user-attachments/assets/3131d96e-9996-4e17-b507-bf82eb7df768)

Hoping this can spare teams similar confusion in the future.

